### PR TITLE
Check that mINT is an actual pin before calling pinMode() in begin

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -235,7 +235,9 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
   }
 //----------------------------------- CS pin
   if (errorCode == 0) {
-    pinMode (mINT, INPUT_PULLUP) ;
+    if (mINT != 255) { // 255 means interrupt is not used
+      pinMode (mINT, INPUT_PULLUP) ;
+    }
     deassertCS () ;
     pinMode (mCS, OUTPUT) ;
   //----------------------------------- Set SPI clock to 1 MHz


### PR DESCRIPTION
 Check that mINT is an actual pin before calling pinMode() in begin, for cases where an interrupt routine and pin are not being used. This change matches what already exists in the MCP2517 repo