### PR TITLE
Fix Interrupt not working on Atmega Devices

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -476,7 +476,7 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
       #ifdef ARDUINO_ARCH_ESP32
         attachInterrupt (itPin, inInterruptServiceRoutine, FALLING) ;
       #else
-        attachInterrupt (digitalPinToInterrupt (itPin), inInterruptServiceRoutine, LOW) ;
+        attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ;
      //   mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
       #endif
     }


### PR DESCRIPTION
A few lines above we already set itPin to the interrupt number of the Input pin, if we do this here again we are causing issues.

This might also be related to the ESP32 ifdef being wrong, it could also be that this has to be a #ifndef but I can not verify that.