### PR TITLE
Re-enable SPI.usingInterrupt for non-ESP32 CPUs

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -477,7 +477,7 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
         attachInterrupt (itPin, inInterruptServiceRoutine, FALLING) ;
       #else
         attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ; // Thank to Flole998
-     //   mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
+        mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
       #endif
     }
   }


### PR DESCRIPTION
Enabling this allows using this library while other devices are connected to the SPI Bus aswell.