### PR TITLE
Fix: mHardwareTxFIFOFull = true will block the transmiter if call beg…

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -511,6 +511,13 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
         mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
       #endif
     }
+
+    /*
+     * If you begin() multiple times without constructor,
+     * mHardwareTxFIFOFull = true will block the transmitter.
+     */
+    mHardwareTxFIFOFull = false;
+    mHardwareReceiveBufferOverflowCount = 0;
   }
 //---
   return errorCode ;

--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -1174,8 +1174,8 @@ uint32_t ACAN2517FD::errorCounters (void) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-uint32_t ACAN2517FD::diagInfos (void) { // thanks to Flole998
-  return readRegister32 (BDIAG1_REGISTER) ;
+uint32_t ACAN2517FD::diagInfos (int index) { // thanks to Flole998
+  return readRegister32 (index? BDIAG1_REGISTER: BDIAG0_REGISTER) ;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/ACAN2517FD.h
+++ b/src/ACAN2517FD.h
@@ -91,7 +91,7 @@ class ACAN2517FD {
 //    Get diagnostic information (thanks to Flole998)
 //······················································································································
 
-  public: uint32_t diagInfos (void) ;
+  public: uint32_t diagInfos (int index = 1) ;
 
 //······················································································································
 //    Current MCP2517FD Operation Mode


### PR DESCRIPTION
…in() multiple times without constructor