### PR TITLE
Optionally disable MCP2517FD workarounds

### DIFF
--- a/src/ACAN2517FD.h
+++ b/src/ACAN2517FD.h
@@ -16,6 +16,16 @@
 #include <SPI.h>
 
 //----------------------------------------------------------------------------------------------------------------------
+//   Settings
+//----------------------------------------------------------------------------------------------------------------------
+//
+// Enable this if you want to disable the MCP2517FD compatability mode. This can slightly increase performance when
+// running on the MCP2518FD but you risk hitting issues mentioned in the MCP2517FD errata-sheet when using this option
+// on the MCP2517FD.
+//
+// #define DISABLEMCP2517FDCOMPAT
+
+//----------------------------------------------------------------------------------------------------------------------
 //   ACAN2517FD class
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
By default this does nothing, when enabling the compile-time-define DISABLEMCP2517FDCOMPAT it no longer disables interrupts during SPI transactions which slightly increases performance and avoids delaying interrupts (which could be problematic on dimmers for example as they may start flickering).

I took this chance to move the duplicate enable/disable code to it's own function that is always inlined, so this just improved readability but shouldn't affect the generated machine code at all.

This new option should be added to the documentation PDF aswell.