### PR TITLE
Avoid race condition during interrupt attachment

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -507,8 +507,8 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
       #ifdef ARDUINO_ARCH_ESP32
         attachInterrupt (itPin, inInterruptServiceRoutine, FALLING) ;
       #else
-        attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ; // Thank to Flole998
         mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
+        attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ; // Thank to Flole998
       #endif
     }
   // If you begin() multiple times without constructor,


### PR DESCRIPTION
We used to attach first and then register our interrupt with the SPI library. In between these steps an interrupt could occur causing issues. So we should first register it with the SPI library and then attach it.