### PR TITLE
Optionally disable 2517FD workarounds

### DIFF
--- a/src/ACAN2517FD.cpp
+++ b/src/ACAN2517FD.cpp
@@ -174,6 +174,30 @@ static uint16_t u16FromBufferAtIndex (uint8_t ioBuffer [], const uint8_t inIndex
 
 //------------------------------------------------------------------------------
 
+static inline void turnOffInterrupts () {
+  #ifndef DISABLEMCP2517FDCOMPAT
+    #ifdef ARDUINO_ARCH_ESP32
+      taskDISABLE_INTERRUPTS () ;
+    #else
+      noInterrupts () ;
+    #endif
+  #endif
+}
+
+//------------------------------------------------------------------------------
+
+static inline void turnOnInterrupts() {
+  #ifndef DISABLEMCP2517FDCOMPAT
+    #ifdef ARDUINO_ARCH_ESP32
+      taskENABLE_INTERRUPTS () ;
+    #else
+      interrupts () ;
+    #endif
+  #endif
+}
+
+//------------------------------------------------------------------------------
+
 ACAN2517FD::ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                         SPIClass & inSPI, // Hardware SPI object
                         const uint8_t inINT) : // INT output of MCP2517FD
@@ -527,11 +551,7 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
 
 bool ACAN2517FD::end (void) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
   //--- Detach interrupt pin
     if (mINT != 255) { // 255 means interrupt is not used
       const int8_t itPin = digitalPinToInterrupt (mINT) ;
@@ -566,11 +586,7 @@ bool ACAN2517FD::end (void) {
     mDriverReceiveBuffer.initWithSize (0) ;
     mDriverTransmitBuffer.initWithSize (0) ;
   //---
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 //---
   return ok ;
@@ -584,11 +600,7 @@ bool ACAN2517FD::tryToSend (const CANFDMessage & inMessage) {
   bool ok = inMessage.isValid () ;
   if (ok) {
     mSPI.beginTransaction (mSPISettings) ;
-      #ifdef ARDUINO_ARCH_ESP32
-        taskDISABLE_INTERRUPTS () ;
-      #else
-        noInterrupts () ;
-      #endif
+      turnOffInterrupts () ;
         if (inMessage.idx == 0) {
           ok = inMessage.len <= mTransmitFIFOPayload ;
           if (ok) {
@@ -600,11 +612,7 @@ bool ACAN2517FD::tryToSend (const CANFDMessage & inMessage) {
             ok = sendViaTXQ (inMessage) ;
           }
         }
-      #ifdef ARDUINO_ARCH_ESP32
-        taskENABLE_INTERRUPTS () ;
-      #else
-        interrupts () ;
-      #endif
+      turnOnInterrupts();
     mSPI.endTransaction () ;
   }
   return ok ;
@@ -771,17 +779,9 @@ bool ACAN2517FD::sendViaTXQ (const CANFDMessage & inMessage) {
 
 bool ACAN2517FD::available (void) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const bool hasReceivedMessage = mDriverReceiveBuffer.count () > 0 ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts();
   mSPI.endTransaction () ;
   return hasReceivedMessage ;
 }
@@ -797,22 +797,14 @@ bool ACAN2517FD::receive (CANFDMessage & outMessage) {
       }else if (!mRxInterruptEnabled) {
 
         mSPI.beginTransaction (mSPISettings) ;
-          #ifdef ARDUINO_ARCH_ESP32
-            taskDISABLE_INTERRUPTS () ;
-          #else
-            noInterrupts () ;
-          #endif
+        turnOffInterrupts () ;
 
         mRxInterruptEnabled = true ;
         uint8_t data8 = readRegister8Assume_SPI_transaction (INT_REGISTER + 2) ;
         data8 |= (1 << 1) ; // Receive FIFO Interrupt Enable
         writeRegister8Assume_SPI_transaction (INT_REGISTER + 2, data8) ;
 
-        #ifdef ARDUINO_ARCH_ESP32
-          taskENABLE_INTERRUPTS () ;
-        #else
-          interrupts () ;
-        #endif
+        turnOnInterrupts();
       mSPI.endTransaction () ;
       }
   return hasReceivedMessage ;
@@ -854,9 +846,9 @@ bool ACAN2517FD::dispatchReceivedMessage (const tFilterMatchCallBack inFilterMat
 
 #ifndef ARDUINO_ARCH_ESP32
   void ACAN2517FD::poll (void) {
-    noInterrupts () ;
+    turnOffInterrupts () ;
       isr_poll_core () ;
-    interrupts () ;
+    turnOnInterrupts () ;
   }
 #endif
 
@@ -1102,17 +1094,9 @@ uint8_t ACAN2517FD::readRegister8Assume_SPI_transaction (const uint16_t inRegist
 
 void ACAN2517FD::writeRegister8 (const uint16_t inRegisterAddress, const uint8_t inValue) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       writeRegister8Assume_SPI_transaction (inRegisterAddress, inValue) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 
@@ -1120,17 +1104,9 @@ void ACAN2517FD::writeRegister8 (const uint16_t inRegisterAddress, const uint8_t
 
 uint8_t ACAN2517FD::readRegister8 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint8_t result = readRegister8Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1139,17 +1115,9 @@ uint8_t ACAN2517FD::readRegister8 (const uint16_t inRegisterAddress) {
 
 uint16_t ACAN2517FD::readRegister16 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint16_t result = readRegister16Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1158,17 +1126,9 @@ uint16_t ACAN2517FD::readRegister16 (const uint16_t inRegisterAddress) {
 
 void ACAN2517FD::writeRegister32 (const uint16_t inRegisterAddress, const uint32_t inValue) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       writeRegister32Assume_SPI_transaction (inRegisterAddress, inValue) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 
@@ -1176,17 +1136,9 @@ void ACAN2517FD::writeRegister32 (const uint16_t inRegisterAddress, const uint32
 
 uint32_t ACAN2517FD::readRegister32 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint32_t result = readRegister32Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+   turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1238,19 +1190,11 @@ void ACAN2517FD::setOperationMode (const ACAN2517FDSettings::OperationMode inOpe
 
 void ACAN2517FD::reset2517FD (void) {
   mSPI.beginTransaction (mSPISettings) ; // Check RESET is performed with 800 kHz clock
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       assertCS () ;
         mSPI.transfer16 (0x00) ; // Reset instruction: 0x0000
       deassertCS () ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 

--- a/src/ACAN2517FD.h
+++ b/src/ACAN2517FD.h
@@ -14,6 +14,16 @@
 #include <ACAN2517FDFilters.h>
 #include <SPI.h>
 
+//----------------------------------------------------------------------------------------------------------------------
+//   Settings
+//----------------------------------------------------------------------------------------------------------------------
+//
+// Enable this if you want to disable the MCP2517FD compatability mode. This can slightly increase performance when
+// running on the MCP2518FD but you risk hitting issues mentioned in the MCP2517FD errata-sheet when using this option
+// on the MCP2517FD.
+//
+// #define DISABLEMCP2517FDCOMPAT
+
 //------------------------------------------------------------------------------
 //   ACAN2517FD class
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This is a recent take on the stale PR https://github.com/pierremolinaro/acan2517FD/pull/34 (I really want this merged, been running this since 2024! :) )

### What
This PR adds a compatibility toggle, that when enabled improves performance when running on MCP2518FD hardware.

### Why
On CAN bus load heavy systems, you might require all the performance you can get. When emulating a full CAN-FD network for a Volkswagen ID3 with this library, the compatibility toggle has a noticeable performance increase. This change has been tested on over 20 devices running MCP2518FD chips. It is a highly recommended setting to enable when running with MCP2518FD chips

### How
To enable this functionality, uncomment the line `// #define DISABLEMCP2517FDCOMPAT` in the `src/ACAN2517FD.h` file

By default this is NOT enabled, so the code will run as normal on both 2517FD and 2518FD.
